### PR TITLE
Remove one of the two GitHub buttons from the documentation page

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "next/core-web-vitals",
+  "extends": ["next/babel","next/core-web-vitals"],
   "rules": {
     "react/no-unescaped-entities": "off"
   }

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -26,7 +26,7 @@ export function GithubButton() {
 export function Footer() {
   return (
     <>
-      <Container className="bottom-2 w-full" style={{ position: 'fixed' }}>
+      <Container className="bottom-2 w-[90%]" style={{ position: 'fixed' }}>
         <div className="flex justify-end md:flex-1">
           <div className="pointer-events-auto">
             <Link target="_blank" href="https://github.com/sparckles/robyn">

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -26,9 +26,9 @@ export function GithubButton() {
 export function Footer() {
   return (
     <>
-      <Container className="bottom-2 w-[90%]" style={{ position: 'fixed' }}>
-        <div className="flex justify-end md:flex-1">
-          <div className="pointer-events-auto">
+      <Container className="bottom-2 w-[90%] z-40" style={{ position: 'fixed' }}>
+        <div className="flex justify-end md:flex-1 ]">
+          <div className="pointer-events-auto ">
             <Link target="_blank" href="https://github.com/sparckles/robyn">
               <GithubButton />
             </Link>

--- a/src/components/releases/Intro.jsx
+++ b/src/components/releases/Intro.jsx
@@ -36,7 +36,6 @@ export function Intro() {
         All the latest Robyn releases,
         <span className="text-yellow-300"> right here.</span>
       </h1>
-      <SignUpForm />
       <div className="mt-8 flex flex-wrap justify-center gap-x-1 gap-y-3 sm:gap-x-2 lg:justify-start">
         <IconLink href="/documentation" icon={BookIcon} className="flex-none">
           Documentation

--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -47,15 +47,7 @@ export default function App({ Component, pageProps, router }) {
             <Component {...pageProps} />
           </Layout>
         </MDXProvider>
-        <Container className="bottom-2 w-full" style={{ position: 'fixed' }}>
-          <div className="flex justify-end md:flex-1">
-            <div className="pointer-events-auto">
-              <Link target="_blank" href="https://github.com/sparckles/robyn">
-                <GithubButton />
-              </Link>
-            </div>
-          </div>
-        </Container>
+        
       </>
     )
   } else if (router_.pathname.includes('release')) {

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -492,7 +492,7 @@ export default function Home({ articles }) {
               </p>
               <div className="mt-10 flex items-center justify-center gap-x-6">
                 <a
-                  href="#"
+                  href="/documentation"
                   className="rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
                 >
                   Get started


### PR DESCRIPTION
issue #15 has been fixed here. 
now one github button will appear properly on the right bottom corner of the documentation page